### PR TITLE
reproducibility fixed for 2024

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -28,6 +28,11 @@ Then build the rcnn module by running :
 ```
 make
 ```
+
+Load retinafaceweights.npy weights : 
+```
+git lfs pull
+```
 <a name="Usage"></a>
 ## USAGE
 Run  :

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# if some of versions is not found in pip it can be found in conda-forge
 tensorflow==2.4.0
 opencv-python
 cython
+wget


### PR DESCRIPTION
#28 

fixed tricky pitfall: misleading numpy error combined with git-lfs usage https://stackoverflow.com/questions/60191681/cannot-load-file-containing-pickled-data-python-npy-i-o

.npy is by default is only git-lfs link and had to be pulled manually in previous repo setting

![git-lfs 134B ](https://github.com/StanislasBertrand/RetinaFace-tf2/assets/20603530/34f67562-76d9-4fbb-98d2-2370bca73ef1)

